### PR TITLE
Trivial bug fixes.

### DIFF
--- a/autoload/gf/autoload.vim
+++ b/autoload/gf/autoload.vim
@@ -29,7 +29,7 @@ set cpo&vim
 
 function! gf#autoload#find()
   let isk = &iskeyword
-  set iskeyword +=:,<,>
+  set iskeyword +=:,<,>,#
   try
     let line = getline('.')
     let start = s:find_start(line, col('.'))

--- a/autoload/gf/autoload.vim
+++ b/autoload/gf/autoload.vim
@@ -67,7 +67,7 @@ endfunction
 
 
 function! s:search_line(path, term)
-  let line = match(readfile(a:path), '\s*fu\%[nction]!\?\s*'.a:term)
+  let line = match(readfile(a:path), '\s*fu\%[nction]!\?\s*' . a:term . '\>')
   if line >= 0
     return line+1
   endif


### PR DESCRIPTION
以下の修正を加えました。
- iskeywordに#が含まれていないとき、うまく関数定義を開けなかったので、一時的に#を加えた
- prefixが同じ関数が複数あるとき、うまく関数定義を探せなかったため、正規表現を一部修正
  
  e.g. hoge#fuga#piyo vs hoge#fuga#piyopuyo
